### PR TITLE
SV FastSim vs. Full Sim Scale Factors

### DIFF
--- a/python/colors.py
+++ b/python/colors.py
@@ -39,8 +39,9 @@ def main():
     
     # check that input file exists
     if not os.path.isfile(input_name):
-        print("ERROR: The input file \"{0}\" does not exist.".format(input_name))
-        print("Download this required text file using \"wget https://xkcd.com/color/rgb.txt\"")
+        print("ERROR: The required input file \"{0}\" does not exist.".format(input_name))
+        print(" - First, download this required text file using \"wget https://xkcd.com/color/rgb.txt\"")
+        print(" - Then run this script again to produce \"{0}\"".format(output_name))
         return
     
     with open(input_name, "r") as input_file:

--- a/python/makePlotsHistos.py
+++ b/python/makePlotsHistos.py
@@ -57,7 +57,6 @@ def plotEras(input_dir, plot_dir, input_files, eras, mc_type, variable, h_name, 
     legend_y2 = 0.90
     # legend: TLegend(x1,y1,x2,y2)
     legend = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
-
     tools.setupLegend(legend)
     
     # draw histos

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -212,13 +212,13 @@ def make_overlay_plot(hists_, suffix_, output_name_):
                 
                 # Draw title
                 title_x = -999
-                title_y = 1.0
+                title_y = 1.1
                 if "PT" in hist:
-                    title_x = 15.0
+                    title_x = 13.0
                 elif "Eta" in hist:
-                    title_x = 1.5
+                    title_x = 0.5
                 mark = rt.TLatex()
-                mark.SetTextSize(0.05)
+                mark.SetTextSize(0.03)
                 mark.DrawLatex(title_x, title_y, title)
 
         can.cd()

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from plotting_susy_cff import plot_configurables as pc
 from plotting_susy_cff import sample_configurables as sc
 import imp, os
+import tools
 
 date = strftime('%d%b%y', localtime())
 #date = date + '_eff'
@@ -179,7 +180,6 @@ def make_overlay_plot(hists_, suffix_, output_name_):
 
                 nbins = hists_tmp[hist][sample][tree].GetNbinsX()
                 print("NBINS: output_name_: {0}, hist: {1}, number of bins: {2}".format(output_name_, hist, nbins))
-
    
                 hists_tmp[hist][sample][tree].SetTitle(title)
                 hists_tmp[hist][sample][tree].GetXaxis().SetTitle(pc[hist]['xlabel'])
@@ -950,9 +950,12 @@ def read_in_hists(in_file_):
     # print(" --- hists (end) --- ")
     return hists 
 
-def make_new_hists(hists_, output_name_):
+# TODO:
+# Fix error: Error in <TH1D::Divide>: Cannot divide histograms with different number of bins
+# Fix rebinning (works for some ratios, but breaks others)
+def make_new_hists(hists_, output_file_name_):
     print("make_new_hists(): start")
-    output_file = rt.TFile(output_name_ + ".root", "RECREATE")
+    output_file = rt.TFile(output_file_name_, "RECREATE")
     DO_REBIN  = True
     REBIN_NUM = 5
     temp_new = OrderedDict()
@@ -1110,12 +1113,15 @@ if __name__ == "__main__":
         "TTJets_FullSim_2018" : "output_files_24May22/output_background_hist_b_eff_TTJets_FullSim_2018.root",
     }
 
-    the_map = file_map_v6
+    the_map     = file_map_v6
+    output_dir  = "sv_eff"
+    tools.makeDir(output_dir)
     
     for output_name in the_map:
         print(" - Process {0}".format(output_name))
         background_file = the_map[output_name]
+        output_file_name = "{0}/{1}_sv_eff.root".format(output_dir, output_name)
         b_hists         = read_in_hists(background_file)
-        b_hists_new     = make_new_hists(b_hists, output_name)
+        b_hists_new     = make_new_hists(b_hists, output_file_name)
         make_overlay_plot(b_hists_new, suffix, output_name)
     

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -3,6 +3,7 @@
 import ROOT
 import numpy as np
 import tools
+import csv
 
 # Make sure ROOT.TFile.Open(fileURL) does not seg fault when $ is in sys.argv (e.g. $ passed in as argument)
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -13,12 +14,12 @@ ROOT.TH1.AddDirectory(False)
 
 # TODO:
 # - save output ROOT files of double ratio
-# - save stats in text or csv file
 # DONE:
 # - loop over plotting function instead of copy/paste
 # - move input ROOT files to directory
 # - add labels to plots (title, axis, name, etc)
 # - use fixed x, y ranges in plots 
+# - save stats in a csv file
 
 # get bins values from histogram for a range of bins
 # include values from start and end bins
@@ -29,14 +30,21 @@ def getBinValues(hist, start_bin, end_bin):
     return values
 
 # given file names and histogram names, plot a ratio of histograms
-def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, variable):
+def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, info, output_writer):
+    # get info from info :-)
+    year        = info["year"]
+    flavor      = info["flavor"]
+    variable    = info["variable"]
+    
+    # load files and histos
     f_num = ROOT.TFile(f_num_name)
     f_den = ROOT.TFile(f_den_name)
     h_num = f_num.Get(h_num_name)
     h_den = f_den.Get(h_den_name)
+    
     # check if histos loaded successfully
-    print("h_num: {0}".format(h_num))
-    print("h_den: {0}".format(h_den))
+    #print("h_num: {0}".format(h_num))
+    #print("h_den: {0}".format(h_den))
     quit = False
     if not h_num:
         print("ERROR: h_num does not exist.")
@@ -48,7 +56,7 @@ def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_nam
         print("Quitting now.")
         return
     
-    # TODO:save num, den, and ratio histograms in a new root file
+    # TODO: save num, den, and ratio histograms in a new root file
 
     # axis labels
     labels = {
@@ -80,11 +88,19 @@ def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_nam
         start_bin = 3
         end_bin   = 18
     values = getBinValues(h_ratio, start_bin, end_bin)
-    print("name: {0}, n_values: {1}, mean: {2:.3f}, std dev: {3:.3f}".format(plot_name, len(values), np.mean(values), np.std(values)))
+    n_values    = len(values)
+    mean        = np.mean(values)
+    std_dev     = np.std(values)
+    mean_rnd    = round(mean, 3)
+    std_dev_rnd = round(std_dev, 3)
+    # output_column_titles = ["name", "year", "flavor", "variable", "n_values", "mean", "std_dev"]
+    output_row = ["FastOverFull", year, flavor, variable, n_values, mean_rnd, std_dev_rnd]
+    output_writer.writerow(output_row)
+    #print("name: {0}, n_values: {1}, mean: {2:.3f}, std_dev: {3:.3f}".format(plot_name, n_values, mean_rnd, std_dev_rnd))
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
 # create plots for different years, flavors, and variables
-def run(input_dir, plot_dir, years, flavors, variables):
+def run(input_dir, plot_dir, years, flavors, variables, output_writer):
     # make plot_dir if it does not exist
     tools.makeDir(plot_dir)
     # loop over years, flavors, and variables
@@ -93,23 +109,33 @@ def run(input_dir, plot_dir, years, flavors, variables):
             for variable in variables:
                 # numerator:    FastSim SV eff.
                 # denominator:  FullSim SV eff.
+                info = {}
+                info["year"]        = year
+                info["flavor"]      = flavor
+                info["variable"]    = variable
                 plot_name  = "TTJets_{0}_FastOverFull_{1}_{2}".format(year, flavor, variable)
                 f_num_name = "{0}/TTJets_FastSim_{1}_sv_eff.root".format(input_dir, year) 
                 f_den_name = "{0}/TTJets_FullSim_{1}_sv_eff.root".format(input_dir, year)
                 h_num_name = "{0}_discr_div_nojets_TTJets_FastSim_{1}_{2}_KUAnalysis".format(variable, year, flavor) 
                 h_den_name = "{0}_discr_div_nojets_TTJets_FullSim_{1}_{2}_KUAnalysis".format(variable, year, flavor)
-                plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, variable)
+                plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, info, output_writer)
 
 def main():
-    # input_dir:    directory for input SV eff. ROOT files
-    # plot_dir:     directory for output plots
-    input_dir   = "sv_eff"
-    plot_dir    = "plots_FastOverFull"
+    # input_dir:        directory for input SV eff. ROOT files
+    # plot_dir:         directory for output plots
+    # csv_output_name:  name of output csv file with mean and std dev of scale factors
+    input_dir       = "sv_eff"
+    plot_dir        = "plots_FastOverFull"
+    csv_output_name = "sv_FastOverFull.csv"
     years       = ["2016", "2017", "2018"]
     flavors     = ["isB", "isC", "isLight"]
     variables   = ["PT", "Eta"]
-    
-    run(input_dir, plot_dir, years, flavors, variables)
+
+    output_column_titles = ["name", "year", "flavor", "variable", "n_values", "mean", "std_dev"]
+    with open(csv_output_name, 'w') as output_csv:
+        output_writer = csv.writer(output_csv)
+        output_writer.writerow(output_column_titles)
+        run(input_dir, plot_dir, years, flavors, variables, output_writer)
 
 if __name__ == "__main__":
     main()

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -1,0 +1,171 @@
+# quick_ratio.py
+
+import ROOT
+
+def getHisto(f_name, h_name):
+    f = ROOT.TFile(f_name)
+    h = f.Get(h_name)
+    print("h: {0}".format(h))
+    return h
+
+def plot(h_num, h_den, plot_name):
+    c = ROOT.TCanvas("c", "c", 800, 800)
+    h_ratio = h_num.Clone("h_ratio")
+    h_ratio.Divide(h_den)
+    h_ratio.Draw()
+    c.SaveAs(plot_name + ".pdf")
+
+def plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
+    plot_dir = "plots_FastOverFull"
+    f_num = ROOT.TFile(f_num_name)
+    f_den = ROOT.TFile(f_den_name)
+    h_num = f_num.Get(h_num_name)
+    h_den = f_den.Get(h_den_name)
+    print("h_num: {0}".format(h_num))
+    print("h_den: {0}".format(h_den))
+    # save num, den, and ratio histograms in a new root file
+
+    # plot ratio; save as pdf
+    c = ROOT.TCanvas("c", "c", 800, 800)
+    h_ratio = h_num.Clone("h_ratio")
+    h_ratio.Divide(h_den)
+    h_ratio.Draw()
+    c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
+
+def main():
+    #h_num = getHisto(f_num_name, h_num_name)
+    #h_den = getHisto(f_den_name, h_den_name)
+    #plot(h_num, h_den, plot_name)
+    
+    # --- 2016 --- #
+    plot_name  = "TTJets_2016_FastOverFull_isB_PT"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isB_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2016_FastOverFull_isB_Eta"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isB_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2016_FastOverFull_isC_PT"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isC_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2016_FastOverFull_isC_Eta"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isC_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2016_FastOverFull_isLight_PT"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isLight_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2016_FastOverFull_isLight_Eta"
+    f_num_name = "TTJets_FastSim_2016.root"
+    f_den_name = "TTJets_FullSim_2016.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isLight_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    # --- 2017 --- #
+    plot_name  = "TTJets_2017_FastOverFull_isB_PT"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isB_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2017_FastOverFull_isB_Eta"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isB_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2017_FastOverFull_isC_PT"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isC_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2017_FastOverFull_isC_Eta"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isC_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2017_FastOverFull_isLight_PT"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isLight_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2017_FastOverFull_isLight_Eta"
+    f_num_name = "TTJets_FastSim_2017.root"
+    f_den_name = "TTJets_FullSim_2017.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isLight_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    # --- 2018 --- #
+    plot_name  = "TTJets_2018_FastOverFull_isB_PT"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isB_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2018_FastOverFull_isB_Eta"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isB_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isB_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2018_FastOverFull_isC_PT"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isC_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2018_FastOverFull_isC_Eta"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isC_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isC_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2018_FastOverFull_isLight_PT"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isLight_KUAnalysis"
+    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    
+    plot_name  = "TTJets_2018_FastOverFull_isLight_Eta"
+    f_num_name = "TTJets_FastSim_2018.root"
+    f_den_name = "TTJets_FullSim_2018.root"
+    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isLight_KUAnalysis"
+    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isLight_KUAnalysis"
+    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+
+if __name__ == "__main__":
+    main()
+

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -11,12 +11,13 @@ ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.TH1.AddDirectory(False)
 
 # TODO:
-# - loop over plotting function instead of copy/paste
-# - move input ROOT files to directory
 # - save output ROOT files of double ratio
 # - save stats in text or csv file
 # - add labels to plots (title, axis, name, etc)
 # - use fixed x, y ranges in plots 
+# DONE:
+# - loop over plotting function instead of copy/paste
+# - move input ROOT files to directory
 
 # get bins values from histogram for a range of bins
 # include values from start and end bins
@@ -33,8 +34,19 @@ def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     f_den = ROOT.TFile(f_den_name)
     h_num = f_num.Get(h_num_name)
     h_den = f_den.Get(h_den_name)
+    # check if histos loaded successfully
     print("h_num: {0}".format(h_num))
     print("h_den: {0}".format(h_den))
+    quit = False
+    if not h_num:
+        print("ERROR: h_num does not exist.")
+        quit = True
+    if not h_den:
+        print("ERROR: h_den does not exist.")
+        quit = True
+    if quit:
+        print("Quitting now.")
+        return
     # save num, den, and ratio histograms in a new root file
 
     # plot ratio; save as pdf
@@ -56,25 +68,27 @@ def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
 # create plots for different years, flavors, and variables
-def run(years, flavors, variables):
+def run(input_dir, years, flavors, variables):
     for year in years:
         for flavor in flavors:
             for variable in variables:
-                # numerator:    FastSim
-                # denominator:  FullSim
+                # numerator:    FastSim SV eff.
+                # denominator:  FullSim SV eff.
                 plot_name  = "TTJets_{0}_FastOverFull_{1}_{2}".format(year, flavor, variable)
-                f_num_name = "TTJets_FastSim_{0}.root".format(year) 
-                f_den_name = "TTJets_FullSim_{0}.root".format(year)
+                f_num_name = "{0}/TTJets_FastSim_{1}_sv_eff.root".format(input_dir, year) 
+                f_den_name = "{0}/TTJets_FullSim_{1}_sv_eff.root".format(input_dir, year)
                 h_num_name = "{0}_discr_div_nojets_TTJets_FastSim_{1}_{2}_KUAnalysis".format(variable, year, flavor) 
                 h_den_name = "{0}_discr_div_nojets_TTJets_FullSim_{1}_{2}_KUAnalysis".format(variable, year, flavor)
                 plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
 
 def main():
+    # input directory with SV eff. ROOT files
+    input_dir   = "sv_eff"
     years       = ["2016", "2017", "2018"]
     flavors     = ["isB", "isC", "isLight"]
     variables   = ["PT", "Eta"]
     
-    run(years, flavors, variables)
+    run(input_dir, years, flavors, variables)
 
 if __name__ == "__main__":
     main()

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -12,13 +12,13 @@ ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.TH1.AddDirectory(False)
 
 # TODO:
-# - use fixed x, y ranges in plots 
-# - add labels to plots (title, axis, name, etc)
 # - save output ROOT files of double ratio
 # - save stats in text or csv file
 # DONE:
 # - loop over plotting function instead of copy/paste
 # - move input ROOT files to directory
+# - add labels to plots (title, axis, name, etc)
+# - use fixed x, y ranges in plots 
 
 # get bins values from histogram for a range of bins
 # include values from start and end bins
@@ -50,13 +50,18 @@ def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_nam
     
     # TODO:save num, den, and ratio histograms in a new root file
 
+    # axis labels
+    labels = {
+        "PT"    : "p_{T} [GeV]",
+        "Eta"   : "#eta"
+    }
     # plot ratio; save as pdf
     c = ROOT.TCanvas("c", "c", 800, 800)
     h_ratio = h_num.Clone("h_ratio")
     h_ratio.Divide(h_den)
     # setup
     title       = plot_name
-    x_title     = variable
+    x_title     = labels[variable]
     y_title     = "(fast sim eff) / (full sim eff)" 
     y_min       = 0.0
     y_max       = 2.0

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -15,13 +15,18 @@ ROOT.TH1.AddDirectory(False)
 # TODO:
 # - save output ROOT files of double ratio
 # - plot efficiencies for multiple years
-# - plot (fast sim eff) / (full sim eff) for multiple years
+# - invert ratio: use (full sim eff) / (fast sim eff)
+# - use less bins: try 10 bins instead of 20
+# - remove extra eta bins
+# - add error bars to eff. plots and eff. ratio plots
+# - to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
 # DONE:
 # - loop over plotting function instead of copy/paste
 # - move input ROOT files to directory
 # - add labels to plots (title, axis, name, etc)
 # - use fixed x, y ranges in plots 
 # - save stats in a csv file
+# - plot (fast sim eff) / (full sim eff) for multiple years
 
 # check that histogram exists
 def histExists(hist_name, hist):

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -29,7 +29,7 @@ def getBinValues(hist, start_bin, end_bin):
     return values
 
 # given file names and histogram names, plot a ratio of histograms
-def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name):
+def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, variable):
     f_num = ROOT.TFile(f_num_name)
     f_den = ROOT.TFile(f_den_name)
     h_num = f_num.Get(h_num_name)
@@ -54,8 +54,18 @@ def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_nam
     c = ROOT.TCanvas("c", "c", 800, 800)
     h_ratio = h_num.Clone("h_ratio")
     h_ratio.Divide(h_den)
+    # setup
+    title       = plot_name
+    x_title     = variable
+    y_title     = "(fast sim eff) / (full sim eff)" 
+    y_min       = 0.0
+    y_max       = 2.0
+    color       = "black"
+    lineWidth   = 3
+    tools.setupHist(h_ratio, title, x_title, y_title, y_min, y_max, color, lineWidth)
+    # draw
     h_ratio.Draw()
-    # define start/end separated for PT, Eta
+    # for values, define start/end bins separately for PT, Eta
     start_bin = 1
     end_bin   = h_ratio.GetNbinsX()
     if "isC" in plot_name:
@@ -83,7 +93,7 @@ def run(input_dir, plot_dir, years, flavors, variables):
                 f_den_name = "{0}/TTJets_FullSim_{1}_sv_eff.root".format(input_dir, year)
                 h_num_name = "{0}_discr_div_nojets_TTJets_FastSim_{1}_{2}_KUAnalysis".format(variable, year, flavor) 
                 h_den_name = "{0}_discr_div_nojets_TTJets_FullSim_{1}_{2}_KUAnalysis".format(variable, year, flavor)
-                plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name)
+                plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name, variable)
 
 def main():
     # input_dir:    directory for input SV eff. ROOT files

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -147,6 +147,15 @@ def plotRatioMultiYear(input_dir, plot_dir, plot_name, years, info):
     # plot ratio; save as pdf
     c = ROOT.TCanvas("c", "c", 800, 800)
     
+    # legend
+    legend_x1 = 0.70
+    legend_x2 = 0.90
+    legend_y1 = 0.70
+    legend_y2 = 0.90
+    # legend: TLegend(x1,y1,x2,y2)
+    legend = ROOT.TLegend(legend_x1, legend_y1, legend_x2, legend_y2)
+    tools.setupLegend(legend)
+    
     # loop over years
     # store histos in map so that they are not overwritten 
     histos = {}
@@ -190,8 +199,12 @@ def plotRatioMultiYear(input_dir, plot_dir, plot_name, years, info):
         tools.setupHist(h_ratio, title, x_title, y_title, y_min, y_max, color, lineWidth)
         # draw
         h_ratio.Draw("same")
+        legend.AddEntry(h_ratio, year, "l")
+    
+    legend.Draw()
     
     # save plot
+    c.Update()
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
 # create plots for different years, flavors, and variables

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -23,6 +23,14 @@ ROOT.TH1.AddDirectory(False)
 # - use fixed x, y ranges in plots 
 # - save stats in a csv file
 
+# check that histogram exists
+def histExists(hist_name, hist):
+    if not hist:
+        print("ERROR: the histogram \"{0}\" does not exist.".format(hist_name))
+        return False
+    else:
+        return True
+
 # get bins values from histogram for a range of bins
 # include values from start and end bins
 def getBinValues(hist, start_bin, end_bin):
@@ -66,18 +74,13 @@ def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_nam
     h_num = f_num.Get(h_num_name)
     h_den = f_den.Get(h_den_name)
     
-    # check if histos loaded successfully
-    #print("h_num: {0}".format(h_num))
-    #print("h_den: {0}".format(h_den))
-    quit = False
-    if not h_num:
-        print("ERROR: h_num does not exist.")
-        quit = True
-    if not h_den:
-        print("ERROR: h_den does not exist.")
-        quit = True
-    if quit:
-        print("Quitting now.")
+    # check that histos exist (loaded successfully)
+    #print("h_num_name: {0}\nh_num: {1}".format(h_num_name, h_num))
+    #print("h_den_name: {0}\nh_den: {1}".format(h_den_name, h_den))
+    h_num_exists = histExists(h_num_name, h_num) 
+    h_den_exists = histExists(h_den_name, h_den) 
+    if not h_num_exists or not h_den_exists:
+        print("The histogram(s) did not load properly. Quitting now.")
         return
     
     # TODO: save num, den, and ratio histograms in a new root file
@@ -138,9 +141,9 @@ def main():
     input_dir       = "sv_eff"
     plot_dir        = "plots_FastOverFull"
     csv_output_name = "sv_FastOverFull.csv"
-    years       = ["2016", "2017", "2018"]
-    flavors     = ["isB", "isC", "isLight"]
-    variables   = ["PT", "Eta"]
+    years           = ["2016", "2017", "2018"]
+    flavors         = ["isB", "isC", "isLight"]
+    variables       = ["PT", "Eta"]
 
     output_column_titles = ["name", "year", "flavor", "variable", "n_values", "mean", "std_dev"]
     with open(csv_output_name, 'w') as output_csv:

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -1,6 +1,9 @@
 # quick_ratio.py
 
 import ROOT
+import numpy as np
+
+ROOT.gROOT.SetBatch()
 
 def getHisto(f_name, h_name):
     f = ROOT.TFile(f_name)
@@ -14,6 +17,12 @@ def plot(h_num, h_den, plot_name):
     h_ratio.Divide(h_den)
     h_ratio.Draw()
     c.SaveAs(plot_name + ".pdf")
+
+def getBinValues(hist, start_bin, end_bin):
+    values = []
+    for i in range(start_bin, end_bin + 1, 1):
+        values.append(hist.GetBinContent(i))
+    return values
 
 def plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     plot_dir = "plots_FastOverFull"
@@ -30,6 +39,17 @@ def plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     h_ratio = h_num.Clone("h_ratio")
     h_ratio.Divide(h_den)
     h_ratio.Draw()
+    # define start/end separated for PT, Eta
+    start_bin = 1
+    end_bin   = h_ratio.GetNbinsX()
+    if "isC" in plot_name:
+        start_bin = 1
+        end_bin   = 18
+    if "Eta" in plot_name:
+        start_bin = 3
+        end_bin   = 18
+    values = getBinValues(h_ratio, start_bin, end_bin)
+    print("name: {0}, n_values: {1}, mean: {2:.3f}, std dev: {3:.3f}".format(plot_name, len(values), np.mean(values), np.std(values)))
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
 def main():

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -2,6 +2,7 @@
 
 import ROOT
 import numpy as np
+import tools
 
 # Make sure ROOT.TFile.Open(fileURL) does not seg fault when $ is in sys.argv (e.g. $ passed in as argument)
 ROOT.PyConfig.IgnoreCommandLineOptions = True
@@ -11,10 +12,10 @@ ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.TH1.AddDirectory(False)
 
 # TODO:
+# - use fixed x, y ranges in plots 
+# - add labels to plots (title, axis, name, etc)
 # - save output ROOT files of double ratio
 # - save stats in text or csv file
-# - add labels to plots (title, axis, name, etc)
-# - use fixed x, y ranges in plots 
 # DONE:
 # - loop over plotting function instead of copy/paste
 # - move input ROOT files to directory
@@ -28,8 +29,7 @@ def getBinValues(hist, start_bin, end_bin):
     return values
 
 # given file names and histogram names, plot a ratio of histograms
-def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
-    plot_dir = "plots_FastOverFull"
+def plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name):
     f_num = ROOT.TFile(f_num_name)
     f_den = ROOT.TFile(f_den_name)
     h_num = f_num.Get(h_num_name)
@@ -47,7 +47,8 @@ def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     if quit:
         print("Quitting now.")
         return
-    # save num, den, and ratio histograms in a new root file
+    
+    # TODO:save num, den, and ratio histograms in a new root file
 
     # plot ratio; save as pdf
     c = ROOT.TCanvas("c", "c", 800, 800)
@@ -68,7 +69,10 @@ def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
 # create plots for different years, flavors, and variables
-def run(input_dir, years, flavors, variables):
+def run(input_dir, plot_dir, years, flavors, variables):
+    # make plot_dir if it does not exist
+    tools.makeDir(plot_dir)
+    # loop over years, flavors, and variables
     for year in years:
         for flavor in flavors:
             for variable in variables:
@@ -79,16 +83,18 @@ def run(input_dir, years, flavors, variables):
                 f_den_name = "{0}/TTJets_FullSim_{1}_sv_eff.root".format(input_dir, year)
                 h_num_name = "{0}_discr_div_nojets_TTJets_FastSim_{1}_{2}_KUAnalysis".format(variable, year, flavor) 
                 h_den_name = "{0}_discr_div_nojets_TTJets_FullSim_{1}_{2}_KUAnalysis".format(variable, year, flavor)
-                plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+                plotRatio(plot_dir, plot_name, f_num_name, f_den_name, h_num_name, h_den_name)
 
 def main():
-    # input directory with SV eff. ROOT files
+    # input_dir:    directory for input SV eff. ROOT files
+    # plot_dir:     directory for output plots
     input_dir   = "sv_eff"
+    plot_dir    = "plots_FastOverFull"
     years       = ["2016", "2017", "2018"]
     flavors     = ["isB", "isC", "isLight"]
     variables   = ["PT", "Eta"]
     
-    run(input_dir, years, flavors, variables)
+    run(input_dir, plot_dir, years, flavors, variables)
 
 if __name__ == "__main__":
     main()

--- a/python/quick_ratio.py
+++ b/python/quick_ratio.py
@@ -3,28 +3,31 @@
 import ROOT
 import numpy as np
 
-ROOT.gROOT.SetBatch()
+# Make sure ROOT.TFile.Open(fileURL) does not seg fault when $ is in sys.argv (e.g. $ passed in as argument)
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+# Make plots faster without displaying them
+ROOT.gROOT.SetBatch(ROOT.kTRUE)
+# Tell ROOT not to be in charge of memory, fix issue of histograms being deleted when ROOT file is closed:
+ROOT.TH1.AddDirectory(False)
 
-def getHisto(f_name, h_name):
-    f = ROOT.TFile(f_name)
-    h = f.Get(h_name)
-    print("h: {0}".format(h))
-    return h
+# TODO:
+# - loop over plotting function instead of copy/paste
+# - move input ROOT files to directory
+# - save output ROOT files of double ratio
+# - save stats in text or csv file
+# - add labels to plots (title, axis, name, etc)
+# - use fixed x, y ranges in plots 
 
-def plot(h_num, h_den, plot_name):
-    c = ROOT.TCanvas("c", "c", 800, 800)
-    h_ratio = h_num.Clone("h_ratio")
-    h_ratio.Divide(h_den)
-    h_ratio.Draw()
-    c.SaveAs(plot_name + ".pdf")
-
+# get bins values from histogram for a range of bins
+# include values from start and end bins
 def getBinValues(hist, start_bin, end_bin):
     values = []
     for i in range(start_bin, end_bin + 1, 1):
         values.append(hist.GetBinContent(i))
     return values
 
-def plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
+# given file names and histogram names, plot a ratio of histograms
+def plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     plot_dir = "plots_FastOverFull"
     f_num = ROOT.TFile(f_num_name)
     f_den = ROOT.TFile(f_den_name)
@@ -52,139 +55,26 @@ def plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name):
     print("name: {0}, n_values: {1}, mean: {2:.3f}, std dev: {3:.3f}".format(plot_name, len(values), np.mean(values), np.std(values)))
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
 
+# create plots for different years, flavors, and variables
+def run(years, flavors, variables):
+    for year in years:
+        for flavor in flavors:
+            for variable in variables:
+                # numerator:    FastSim
+                # denominator:  FullSim
+                plot_name  = "TTJets_{0}_FastOverFull_{1}_{2}".format(year, flavor, variable)
+                f_num_name = "TTJets_FastSim_{0}.root".format(year) 
+                f_den_name = "TTJets_FullSim_{0}.root".format(year)
+                h_num_name = "{0}_discr_div_nojets_TTJets_FastSim_{1}_{2}_KUAnalysis".format(variable, year, flavor) 
+                h_den_name = "{0}_discr_div_nojets_TTJets_FullSim_{1}_{2}_KUAnalysis".format(variable, year, flavor)
+                plotRatio(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+
 def main():
-    #h_num = getHisto(f_num_name, h_num_name)
-    #h_den = getHisto(f_den_name, h_den_name)
-    #plot(h_num, h_den, plot_name)
+    years       = ["2016", "2017", "2018"]
+    flavors     = ["isB", "isC", "isLight"]
+    variables   = ["PT", "Eta"]
     
-    # --- 2016 --- #
-    plot_name  = "TTJets_2016_FastOverFull_isB_PT"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isB_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2016_FastOverFull_isB_Eta"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isB_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2016_FastOverFull_isC_PT"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isC_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2016_FastOverFull_isC_Eta"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isC_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2016_FastOverFull_isLight_PT"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2016_isLight_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2016_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2016_FastOverFull_isLight_Eta"
-    f_num_name = "TTJets_FastSim_2016.root"
-    f_den_name = "TTJets_FullSim_2016.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2016_isLight_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2016_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    # --- 2017 --- #
-    plot_name  = "TTJets_2017_FastOverFull_isB_PT"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isB_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2017_FastOverFull_isB_Eta"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isB_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2017_FastOverFull_isC_PT"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isC_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2017_FastOverFull_isC_Eta"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isC_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2017_FastOverFull_isLight_PT"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2017_isLight_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2017_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2017_FastOverFull_isLight_Eta"
-    f_num_name = "TTJets_FastSim_2017.root"
-    f_den_name = "TTJets_FullSim_2017.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2017_isLight_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2017_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    # --- 2018 --- #
-    plot_name  = "TTJets_2018_FastOverFull_isB_PT"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isB_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2018_FastOverFull_isB_Eta"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isB_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isB_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2018_FastOverFull_isC_PT"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isC_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2018_FastOverFull_isC_Eta"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isC_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isC_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2018_FastOverFull_isLight_PT"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "PT_discr_div_nojets_TTJets_FastSim_2018_isLight_KUAnalysis"
-    h_den_name = "PT_discr_div_nojets_TTJets_FullSim_2018_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
-    
-    plot_name  = "TTJets_2018_FastOverFull_isLight_Eta"
-    f_num_name = "TTJets_FastSim_2018.root"
-    f_den_name = "TTJets_FullSim_2018.root"
-    h_num_name = "Eta_discr_div_nojets_TTJets_FastSim_2018_isLight_KUAnalysis"
-    h_den_name = "Eta_discr_div_nojets_TTJets_FullSim_2018_isLight_KUAnalysis"
-    plot_v2(f_num_name, f_den_name, h_num_name, h_den_name, plot_name)
+    run(years, flavors, variables)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update make_those_plots.py
- Save SV efficiency histograms to files

New script to calculate fast/full sim scale factors (double ratio of efficiencies): quick_ratio.py 

TODO:
- save output ROOT files of double ratio

DONE:
- loop over plotting function instead of copy/paste
- move input ROOT files to directory
- add labels to plots (title, axis, name, etc)
- use fixed x, y ranges in plots 
- save stats in a csv file