### PR TITLE
Major Updates

### DIFF
--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -105,26 +105,9 @@ def getBinValues(hist, start_bin, end_bin):
 
 # get row for csv output
 def getRow(hist, plot_name, ratio_name, year, flavor, variable):
-    # default: use all bins
-    start_bin = 1
-    end_bin   = hist.GetNbinsX()
-    
-    # use different start/end bins for isC (PT) and Eta (all flavors)
-    
-    # old binning
-    # if "isC" in plot_name:
-    #     start_bin = 1
-    #     end_bin   = 18
-    # if "Eta" in plot_name:
-    #     start_bin = 3
-    #     end_bin   = 18
-    
-    # new binning
-    if "Eta" in plot_name:
-        start_bin += 1
-        end_bin   -= 1
-
-    values = getBinValues(hist, start_bin, end_bin)
+    start_bin   = 1
+    end_bin     = hist.GetNbinsX()
+    values      = getBinValues(hist, start_bin, end_bin)
     n_values    = len(values)
     mean        = np.mean(values)
     std_dev     = np.std(values)

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -1,4 +1,4 @@
-# quick_ratio.py
+# calc_ratio.py
 
 import ROOT
 import numpy as np

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -13,10 +13,9 @@ ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.TH1.AddDirectory(False)
 
 # TODO:
-# - use less bins: try 10 bins instead of 20
-# - remove extra eta bins
 # - add error bars to eff. plots and eff. ratio plots
 # - to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
+# - remove extra eta bins
 # - plot efficiencies for multiple years
 # - save output ROOT files of double ratio
 # DONE:
@@ -27,6 +26,7 @@ ROOT.TH1.AddDirectory(False)
 # - save stats in a csv file
 # - plot (fast sim eff) / (full sim eff) for multiple years
 # - invert ratio: use (full sim eff) / (fast sim eff)
+# - use less bins: try 10 bins instead of 20
 
 # check that histogram exists
 def histExists(hist_name, hist):
@@ -77,13 +77,22 @@ def getRow(hist, plot_name, ratio_name, year, flavor, variable):
     # default: use all bins
     start_bin = 1
     end_bin   = hist.GetNbinsX()
+    
     # use different start/end bins for isC (PT) and Eta (all flavors)
-    if "isC" in plot_name:
-        start_bin = 1
-        end_bin   = 18
+    
+    # old binning
+    # if "isC" in plot_name:
+    #     start_bin = 1
+    #     end_bin   = 18
+    # if "Eta" in plot_name:
+    #     start_bin = 3
+    #     end_bin   = 18
+    
+    # new binning
     if "Eta" in plot_name:
-        start_bin = 3
-        end_bin   = 18
+        start_bin += 1
+        end_bin   -= 1
+
     values = getBinValues(hist, start_bin, end_bin)
     n_values    = len(values)
     mean        = np.mean(values)

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -135,7 +135,7 @@ def getRow(hist, plot_name, ratio_name, year, flavor, variable):
     return output_row
 
 # given file names and histogram names, plot a ratio of histograms
-def plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, use_eff):
+def plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, use_eff, draw_err):
     # TODO: save num, den, and ratio histograms in a new root file
     # get info from info :-)
     year        = info["year"]
@@ -191,8 +191,10 @@ def plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, u
     lineWidth   = 3
     tools.setupHist(h_ratio, title, x_title, y_title, y_min, y_max, color, lineWidth)
     # draw
-    h_ratio.Draw("error")
-    #h_ratio.Draw()
+    if draw_err:
+        h_ratio.Draw("error")
+    else:
+        h_ratio.Draw()
     # save plot
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
     
@@ -201,7 +203,7 @@ def plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, u
     output_writer.writerow(output_row)
 
 # plot ratio of histograms for multiple years on one plot
-def plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, use_eff):
+def plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, use_eff, draw_err):
     # TODO: save num, den, and ratio histograms in a new root file
     # get info from info :-)
     flavor      = info["flavor"]
@@ -283,8 +285,10 @@ def plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, 
         lineWidth   = 3
         tools.setupHist(h_ratio, title, x_title, y_title, y_min, y_max, color, lineWidth)
         # draw
-        h_ratio.Draw("same error")
-        #h_ratio.Draw("same")
+        if draw_err:
+            h_ratio.Draw("same error")
+        else:
+            h_ratio.Draw("same")
         legend.AddEntry(h_ratio, year, "l")
     
     legend.Draw()
@@ -295,7 +299,8 @@ def plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, 
 
 # create plots for different years, flavors, and variables
 def run(ratio_name, input_dir, plot_dir, years, flavors, variables, output_writer):
-    use_eff = True
+    use_eff  = True
+    draw_err = True
     # make plot_dir if it does not exist
     tools.makeDir(plot_dir)
     # loop over years, flavors, and variables
@@ -309,7 +314,7 @@ def run(ratio_name, input_dir, plot_dir, years, flavors, variables, output_write
                 info["flavor"]      = flavor
                 info["variable"]    = variable
                 plot_name  = "TTJets_{0}_{1}_{2}_{3}".format(ratio_name, year, flavor, variable)
-                plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, use_eff)
+                plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer, use_eff, draw_err)
     
     # loop over flavors and variables 
     for flavor in flavors:
@@ -318,7 +323,7 @@ def run(ratio_name, input_dir, plot_dir, years, flavors, variables, output_write
             info["flavor"]      = flavor
             info["variable"]    = variable
             plot_name  = "TTJets_{0}_AllYears_{1}_{2}".format(ratio_name, flavor, variable)
-            plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, use_eff)
+            plotRatioMultiYear(ratio_name, input_dir, plot_dir, plot_name, years, info, use_eff, draw_err)
 
 def main():
     # ratio_name:       name of ratio (e.g. FastOverFull, FullOverFast)

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -15,11 +15,11 @@ ROOT.TH1.AddDirectory(False)
 # TODO:
 # - plot efficiencies for multiple years on the same plot
 # - plot efficiencies for fast sim and full sim on the same plot
-# - add error bars to eff. plots and eff. ratio plots
-# - to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
-# - remove extra eta bins
 # - save output ROOT files of double ratio
 # DONE:
+# - remove extra eta bins
+# - add error bars to eff. plots and eff. ratio plots
+# - to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
 # - loop over plotting function instead of copy/paste
 # - move input ROOT files to directory
 # - add labels to plots (title, axis, name, etc)
@@ -28,6 +28,9 @@ ROOT.TH1.AddDirectory(False)
 # - plot (fast sim eff) / (full sim eff) for multiple years
 # - invert ratio: use (full sim eff) / (fast sim eff)
 # - use less bins: try 10 bins instead of 20
+# NOTES:
+# - Currently for errors on eff. histos, the average of high and low errors from TEfficiency are used. The double ratio has symmetric errors; could maintain asymmetric errors.
+# - Currently for SF, std_dev is used; could instead propagate unc. through calc. of weighted average.
 
 # check that histogram exists
 def histExists(hist_name, hist):

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -73,7 +73,7 @@ def getBinValues(hist, start_bin, end_bin):
     return values
 
 # get row for csv output
-def getRow(hist, plot_name, year, flavor, variable):
+def getRow(hist, plot_name, ratio_name, year, flavor, variable):
     # default: use all bins
     start_bin = 1
     end_bin   = hist.GetNbinsX()
@@ -91,7 +91,7 @@ def getRow(hist, plot_name, year, flavor, variable):
     mean_rnd    = round(mean, 3)
     std_dev_rnd = round(std_dev, 3)
     # output_column_titles = ["name", "year", "flavor", "variable", "n_values", "mean", "std_dev"]
-    output_row = ["FastOverFull", year, flavor, variable, n_values, mean_rnd, std_dev_rnd]
+    output_row = [ratio_name, year, flavor, variable, n_values, mean_rnd, std_dev_rnd]
     return output_row
 
 # given file names and histogram names, plot a ratio of histograms
@@ -150,7 +150,7 @@ def plotRatio(ratio_name, input_dir, plot_dir, plot_name, info, output_writer):
     c.SaveAs(plot_dir + "/" + plot_name + ".pdf")
     
     # save stats to csv file
-    output_row = getRow(h_ratio, plot_name, year, flavor, variable)
+    output_row = getRow(h_ratio, plot_name, ratio_name, year, flavor, variable)
     output_writer.writerow(output_row)
 
 # plot ratio of histograms for multiple years on one plot

--- a/python/calc_ratio.py
+++ b/python/calc_ratio.py
@@ -13,10 +13,11 @@ ROOT.gROOT.SetBatch(ROOT.kTRUE)
 ROOT.TH1.AddDirectory(False)
 
 # TODO:
+# - plot efficiencies for multiple years on the same plot
+# - plot efficiencies for fast sim and full sim on the same plot
 # - add error bars to eff. plots and eff. ratio plots
 # - to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
 # - remove extra eta bins
-# - plot efficiencies for multiple years
 # - save output ROOT files of double ratio
 # DONE:
 # - loop over plotting function instead of copy/paste

--- a/python/make_b_eff_hists_batch.py
+++ b/python/make_b_eff_hists_batch.py
@@ -49,7 +49,7 @@ def get_histograms(list_of_files_, variable_list_, cuts_to_apply_=None):
 
             for sel in selections_str:
                 hist[sample][tree_name.replace('/', '_')]['PT_'+sel]    = rt.TH1D('PT_'+sel+'_'+sample+'_'+tree_name.replace('/', '_'), '', 100, 2, 20)
-                hist[sample][tree_name.replace('/', '_')]['Eta_'+sel]   = rt.TH1D('Eta_'+sel+'_'+sample+'_'+tree_name.replace('/', '_'), '', 100, -np.pi, np.pi)
+                hist[sample][tree_name.replace('/', '_')]['Eta_'+sel]   = rt.TH1D('Eta_'+sel+'_'+sample+'_'+tree_name.replace('/', '_'), '', 100, -2.4, 2.4)
 
 
         for ifile, in_file in enumerate(list_of_files_[sample]['files']):

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -113,11 +113,11 @@ def make_2D_plots(hists_, suffix_):
 
 # main efficiency plot
 def make_overlay_plot(hists_, suffix_, output_name_):
-    print("make_overlay_plot(): start")
+    #print("make_overlay_plot(): start")
     title = output_name_
     hists_tmp = OrderedDict()
     plot_dir = './plots_' + output_name_ + '_' + date
-    print("plot_dir: {0}".format(plot_dir))
+    #print("plot_dir: {0}".format(plot_dir))
     if not (os.path.isdir(plot_dir)):
         os.mkdir(plot_dir)
     out_dir = os.path.join(plot_dir)
@@ -164,7 +164,7 @@ def make_overlay_plot(hists_, suffix_, output_name_):
                 hists_tmp[hist][sample][tree].SetLineWidth(sc[sample]['width'])
                 if sc[sample]['fill']: hists_tmp[hist][sample][tree].SetFillColor(sc[sample]['fill'])
                 if sc[sample]['fill_style']: hists_tmp[hist][sample][tree].SetFillStyle(sc[sample]['fill_style'])
-                print hist, sample, tree
+                #print hist, sample, tree
                 if 'SMS' in sample:
                     stop_m = tree.split('_')[1]
                     neut_m = tree.split('_')[2]
@@ -179,7 +179,7 @@ def make_overlay_plot(hists_, suffix_, output_name_):
                 #hists_tmp[hist][sample][tree].Scale(1/hists_tmp[hist][sample][tree].Integral())
 
                 nbins = hists_tmp[hist][sample][tree].GetNbinsX()
-                print("NBINS: output_name_: {0}, hist: {1}, number of bins: {2}".format(output_name_, hist, nbins))
+                #print("NBINS: output_name_: {0}, hist: {1}, number of bins: {2}".format(output_name_, hist, nbins))
    
                 hists_tmp[hist][sample][tree].SetTitle(title)
                 hists_tmp[hist][sample][tree].GetXaxis().SetTitle(pc[hist]['xlabel'])
@@ -317,7 +317,7 @@ def make_plots(hists_, sig_hists_ = None, print_plots = True, suffix_=''):
             hists_tmp[hist][sample].SetLineWidth(sc[sample]['width'])
             if sc[sample]['fill']: hists_tmp[hist][sample].SetFillColor(sc[sample]['fill'])
             if sc[sample]['fill_style']: hists_tmp[hist][sample].SetFillStyle(sc[sample]['fill_style'])
-            print hist, sample
+            #print hist, sample
             leg.AddEntry(hists_tmp[hist][sample], sc[sample]['legend'], 'fl')
         if sig_hists_:
             for sample in sig_hists_tmp[hist]:
@@ -329,7 +329,7 @@ def make_plots(hists_, sig_hists_ = None, print_plots = True, suffix_=''):
                     sig_hists_tmp[hist][sample][tree].SetLineWidth(sc[sample]['width'])
                     if sc[sample]['fill']: sig_hists_tmp[hist][sample][tree].SetFillColor(sc[sample]['fill'])
                     if sc[sample]['fill_style']: sig_hists_tmp[hist][sample][tree].SetFillStyle(sc[sample]['fill_style'])
-                    print hist, sample, tree
+                    #print hist, sample, tree
                     if 'Events' in tree:
                         stop_m = '500'
                         neut_m = sample.split('_')[-1]
@@ -515,7 +515,7 @@ def make_stacked_plots(hists_, sig_hists_ = None, print_plots = True, suffix_=''
             hists_tmp[hist][sample].SetLineStyle(sc[sample]['style'])
             if sc[sample]['fill']: hists_tmp[hist][sample].SetFillColor(sc[sample]['fill'])
             if sc[sample]['fill_style']: hists_tmp[hist][sample].SetFillStyle(1001)
-            print hist, sample
+            #print hist, sample
             stack[hist].Add(hists_tmp[hist][sample])
             leg.AddEntry(hists_tmp[hist][sample], sc[sample]['legend'], 'fl')
         if sig_hists_:
@@ -527,7 +527,7 @@ def make_stacked_plots(hists_, sig_hists_ = None, print_plots = True, suffix_=''
                     sig_hists_tmp[hist][sample][tree].SetLineWidth(sc[sample]['width'])
                     if sc[sample]['fill']: sig_hists_tmp[hist][sample][tree].SetFillColor(sc[sample]['fill'])
                     if sc[sample]['fill_style']: sig_hists_tmp[hist][sample][tree].SetFillStyle(sc[sample]['fill_style'])
-                    print hist, sample, tree
+                    #print hist, sample, tree
                     if 'Events' in tree:
                         stop_m = '500'
                         neut_m = sample.split('_')[-1]
@@ -704,7 +704,7 @@ def make_data_stacked_plots(data_, hists_, sig_hists_ = None, print_plots = True
             hists_tmp[hist][sample].SetLineStyle(sc[sample]['style'])
             if sc[sample]['fill']: hists_tmp[hist][sample].SetFillColor(sc[sample]['fill'])
             if sc[sample]['fill_style']: hists_tmp[hist][sample].SetFillStyle(1001)
-            print hist, sample
+            #print hist, sample
             stack[hist].Add(hists_tmp[hist][sample])
             leg.AddEntry(hists_tmp[hist][sample], sc[sample]['legend'], 'fl')
         if sig_hists_:
@@ -716,7 +716,7 @@ def make_data_stacked_plots(data_, hists_, sig_hists_ = None, print_plots = True
                     sig_hists_tmp[hist][sample][tree].SetLineWidth(sc[sample]['width'])
                     if sc[sample]['fill']: sig_hists_tmp[hist][sample][tree].SetFillColor(sc[sample]['fill'])
                     if sc[sample]['fill_style']: sig_hists_tmp[hist][sample][tree].SetFillStyle(sc[sample]['fill_style'])
-                    print hist, sample, tree
+                    #print hist, sample, tree
                     if 'Events' in tree:
                         stop_m = '500'
                         neut_m = sample.split('_')[-1]
@@ -840,7 +840,7 @@ def make_data_stacked_plots(data_, hists_, sig_hists_ = None, print_plots = True
 
 
 def make_1D_plots(hists_, suffix_):
-    print("make_1D_plots(): start")
+    #print("make_1D_plots(): start")
     tdrstyle.setTDRStyle()
     if not (os.path.isdir('./plots_'+date)): os.mkdir('./plots_'+date)
     for sample in hists_:
@@ -849,7 +849,7 @@ def make_1D_plots(hists_, suffix_):
             if not (os.path.isdir('./plots_'+date+'/'+sample+'/'+tree)): os.mkdir(os.path.join('./plots_'+date, sample, tree))
             out_dir = os.path.join('./plots_'+date, sample, tree)
             for hist_name, hist in hists_[sample][tree].items():
-                print hist_name, sample
+                #print hist_name, sample
                 if not hist.InheritsFrom(rt.TH1.Class()): continue                   
                 if hist.InheritsFrom(rt.TH2.Class()): continue 
                 if hist_name not in pc: continue
@@ -893,11 +893,11 @@ def make_1D_plots(hists_, suffix_):
 
 def read_in_hists(in_file_):
     USE_OLD_VERSION = False
-    print("read_in_hists(): start")
+    #print("read_in_hists(): start")
     in_file = rt.TFile(in_file_, 'r')
     hists = OrderedDict()
     for key in in_file.GetListOfKeys():
-        print key.GetName()
+        #print key.GetName()
         key_name = key.GetName()
         # WARNING: key_name is skipped if it is not in sc
         if key_name not in sc:
@@ -906,12 +906,12 @@ def read_in_hists(in_file_):
         sample_dir = in_file.Get(key.GetName())
         hists[key_name] = OrderedDict()
         for tree_key in sample_dir.GetListOfKeys():
-            print tree_key.GetName()
+            #print tree_key.GetName()
             tree_name = tree_key.GetName()
             tree_dir = sample_dir.Get(tree_key.GetName())
             hists[key_name][tree_name] = OrderedDict()
             for hist_key in tree_dir.GetListOfKeys():
-                print hist_key.GetName()
+                #print hist_key.GetName()
                 hist_name = hist_key.GetName()
                 hist = tree_dir.Get(hist_key.GetName())
                 # debugging
@@ -954,7 +954,7 @@ def read_in_hists(in_file_):
 # Fix error: Error in <TH1D::Divide>: Cannot divide histograms with different number of bins
 # Fix rebinning (works for some ratios, but breaks others)
 def make_new_hists(hists_, output_file_name_):
-    print("make_new_hists(): start")
+    #print("make_new_hists(): start")
     output_file = rt.TFile(output_file_name_, "RECREATE")
     DO_REBIN  = True
     REBIN_NUM = 10
@@ -968,7 +968,7 @@ def make_new_hists(hists_, output_file_name_):
             for hist_name, hist in hists_[sample][tree].items():
                 new_hist = None
                 if 'all' in hist_name:
-                    print sample, tree, hist_name
+                    #print sample, tree, hist_name
                     
                     new_hist = hist_name.replace('all', 'all_div_nojets')
                     temp_new[sample][tree][new_hist] = hist.Clone(hist.GetName().replace('all', 'all_div_nojets'))
@@ -1009,15 +1009,36 @@ def make_new_hists(hists_, output_file_name_):
                         #    hists_[sample][tree][hist_name.replace('discr_ntrk','ntrk')].Rebin(REBIN_NUM)
                         temp_new[sample][tree][new_hist_2].Divide(hists_[sample][tree][hist_name.replace('discr_ntrk','ntrk')])
                     else:
-                        new_hist = hist_name.replace('discr', 'discr_div_nojets')
-                        temp_new[sample][tree][new_hist] = hist.Clone(hist.GetName().replace('discr','discr_div_nojets'))
+                        den_name        = hist_name.replace('discr','nojets')
+                        ratio_name      = hist_name.replace('discr', 'discr_div_nojets')
+                        long_name       = hist.GetName()
+                        new_long_name   = hist.GetName().replace('discr','discr_div_nojets') 
+                        # print names:
+                        print("# --------------------------------------- #")
+                        print("hist_name: {0}".format(hist_name))
+                        print("den_name: {0}".format(den_name))
+                        print("ratio_name: {0}".format(ratio_name))
+                        print("long_name: {0}".format(long_name))
+                        print("new_long_name: {0}".format(new_long_name))
+                        print("# --------------------------------------- #")
+                        temp_new[sample][tree][ratio_name] = hist.Clone(new_long_name)
                         # rebin hists before dividing
                         if DO_REBIN:
-                            temp_new[sample][tree][new_hist].Rebin(REBIN_NUM)
-                            hists_[sample][tree][hist_name.replace('discr','nojets')].Rebin(REBIN_NUM)
-                        temp_new[sample][tree][new_hist].Divide(hists_[sample][tree][hist_name.replace('discr','nojets')])
+                            temp_new[sample][tree][ratio_name].Rebin(REBIN_NUM)
+                            hists_[sample][tree][den_name].Rebin(REBIN_NUM)
+                        # number of bins:
+                        print("{0}: n_bins = {1}".format(ratio_name, temp_new[sample][tree][ratio_name].GetNbinsX()))
+                        print("{0}: n_bins = {1}".format(den_name,   hists_[sample][tree][den_name].GetNbinsX()))
+                        # efficiency: do this before taking ratio!!
+                        # TEfficiency::CheckConsistency(h_pass,h_total)
+                        if rt.TEfficiency.CheckConsistency(temp_new[sample][tree][ratio_name], hists_[sample][tree][den_name]):
+                            print("PASS CheckConsistency: {0} and {1}".format(ratio_name, den_name))
+                            h_eff = rt.TEfficiency(temp_new[sample][tree][ratio_name], hists_[sample][tree][den_name])
+                            h_eff.Write()
+                        # ratio
+                        temp_new[sample][tree][ratio_name].Divide(hists_[sample][tree][den_name])
                         # save ratio to file
-                        temp_new[sample][tree][new_hist].Write()
+                        temp_new[sample][tree][ratio_name].Write()
 
                     #zero_value = temp_new[sample][tree][new_hist].GetBinContent(1)
                     #temp_new[sample][tree][new_hist].Scale(1./zero_value)
@@ -1032,7 +1053,7 @@ def read_in_hists_opt(in_file_):
     hists = OrderedDict()
     for key in in_file.GetListOfKeys():
         key_name = key.GetName()
-        print key_name
+        #print key_name
         key_split = key_name.split('__')
         sample = key_split[0]
         tree = key_split[1]
@@ -1081,8 +1102,6 @@ if __name__ == "__main__":
     
     # old 2017 version
     #background_file = 'data/output_background_hist_sv_b_eff_09Dec20.root'
-    # run 2 version
-
     
     #background_file = 'output_background_hist_b_eff_TTJets_FastSim_2016_17May22.root'
     #output_name = "TTJets_FastSim_2016"

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -5,6 +5,7 @@ from plotting_susy_cff import plot_configurables as pc
 from plotting_susy_cff import sample_configurables as sc
 import imp, os
 import tools
+import re
 
 date = strftime('%d%b%y', localtime())
 #date = date + '_eff'
@@ -1034,6 +1035,12 @@ def make_new_hists(hists_, output_file_name_):
                         if rt.TEfficiency.CheckConsistency(temp_new[sample][tree][ratio_name], hists_[sample][tree][den_name]):
                             print("PASS CheckConsistency: {0} and {1}".format(ratio_name, den_name))
                             h_eff = rt.TEfficiency(temp_new[sample][tree][ratio_name], hists_[sample][tree][den_name])
+                            print("(1) h_eff.GetName(): {0}".format(h_eff.GetName()))
+                            h_eff_name = h_eff.GetName()
+                            h_eff_name = re.sub('_clone$', '', h_eff_name)
+                            h_eff_name = h_eff_name + "_eff"
+                            h_eff.SetName(h_eff_name)
+                            print("(2) h_eff.GetName(): {0}".format(h_eff.GetName()))
                             h_eff.Write()
                         # ratio
                         temp_new[sample][tree][ratio_name].Divide(hists_[sample][tree][den_name])

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -1036,9 +1036,7 @@ def make_new_hists(hists_, output_file_name_):
                             print("PASS CheckConsistency: {0} and {1}".format(ratio_name, den_name))
                             h_eff = rt.TEfficiency(temp_new[sample][tree][ratio_name], hists_[sample][tree][den_name])
                             print("(1) h_eff.GetName(): {0}".format(h_eff.GetName()))
-                            h_eff_name = h_eff.GetName()
-                            h_eff_name = re.sub('_clone$', '', h_eff_name)
-                            h_eff_name = h_eff_name + "_eff"
+                            h_eff_name = new_long_name + "_eff"  
                             h_eff.SetName(h_eff_name)
                             print("(2) h_eff.GetName(): {0}".format(h_eff.GetName()))
                             h_eff.Write()

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -1,14 +1,13 @@
-import ROOT as rt
-from time import strftime, localtime
+from datetime import datetime
 from collections import OrderedDict
 from plotting_susy_cff import plot_configurables as pc
 from plotting_susy_cff import sample_configurables as sc
+import ROOT as rt
 import imp, os
 import tools
 import re
 
-date = strftime('%d%b%y', localtime())
-#date = date + '_eff'
+date = datetime.today().strftime('%Y_%m_%d')
 
 rt.gROOT.SetBatch()
 rt.gROOT.SetStyle('Plain')
@@ -1128,7 +1127,7 @@ if __name__ == "__main__":
         "TTJets_FullSim_2018" : "output_files_23May22/output_background_hist_b_eff_TTJets_FullSim_2018.root",
     }
     # v6 ntuples
-    file_map_v6 = {
+    file_map_v6p0 = {
         "TTJets_FastSim_2016" : "output_files_24May22/output_background_hist_b_eff_TTJets_FastSim_2016.root",
         "TTJets_FastSim_2017" : "output_files_24May22/output_background_hist_b_eff_TTJets_FastSim_2017.root",
         "TTJets_FastSim_2018" : "output_files_24May22/output_background_hist_b_eff_TTJets_FastSim_2018.root",
@@ -1136,8 +1135,16 @@ if __name__ == "__main__":
         "TTJets_FullSim_2017" : "output_files_24May22/output_background_hist_b_eff_TTJets_FullSim_2017.root",
         "TTJets_FullSim_2018" : "output_files_24May22/output_background_hist_b_eff_TTJets_FullSim_2018.root",
     }
+    file_map_v6p1 = {
+        "TTJets_FastSim_2016" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FastSim_2016.root",
+        "TTJets_FastSim_2017" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FastSim_2017.root",
+        "TTJets_FastSim_2018" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FastSim_2018.root",
+        "TTJets_FullSim_2016" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FullSim_2016.root",
+        "TTJets_FullSim_2017" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FullSim_2017.root",
+        "TTJets_FullSim_2018" : "output_files_2022_07_13/output_background_hist_b_eff_TTJets_FullSim_2018.root",
+    }
 
-    the_map     = file_map_v6
+    the_map     = file_map_v6p1
     output_dir  = "sv_eff"
     tools.makeDir(output_dir)
     

--- a/python/make_those_plots.py
+++ b/python/make_those_plots.py
@@ -957,7 +957,7 @@ def make_new_hists(hists_, output_file_name_):
     print("make_new_hists(): start")
     output_file = rt.TFile(output_file_name_, "RECREATE")
     DO_REBIN  = True
-    REBIN_NUM = 5
+    REBIN_NUM = 10
     temp_new = OrderedDict()
     for sample in hists_:
         temp_new[sample] = OrderedDict()

--- a/python/numpy_hist_data_svsf_batch.py
+++ b/python/numpy_hist_data_svsf_batch.py
@@ -1,4 +1,4 @@
-from time import strftime, localtime
+from datetime import datetime
 import argparse as arg
 import os, re
 from file_table_functions import *
@@ -8,8 +8,7 @@ import root_numpy as rnp
 from collections import OrderedDict
 import pickle
 
-date = strftime('%d%b%y', localtime())
-
+date = datetime.today().strftime('%Y_%m_%d')
 
 def write_sub(output_dir, src_file, script, file_list, ofile_name, queue_num):
     fsrc = open(os.path.join(output_dir, "submit", src_file+'_'+script+'.submit'), 'w')

--- a/scripts/make_eff_hists.sh
+++ b/scripts/make_eff_hists.sh
@@ -4,9 +4,9 @@
 # May 23, 2022
 
 # Script to run make_b_eff_hists_batch.py and then ahadd.py
-
-input_dir=output_condor_hists_2D_proposal_24May22
-output_dir=output_files_24May22
+today=$(date "+%Y_%m_%d")
+input_dir=output_condor_hists_2D_proposal_${today}
+output_dir=output_files_${today}
 
 # delete directory if it exists
 if [ -d ${output_dir} ]; then


### PR DESCRIPTION
## TODO
- plot efficiencies for multiple years on the same plot
- plot efficiencies for fast sim and full sim on the same plot
- add weighted avg. and unc. to plots
- save output ROOT files of double ratio
## DONE
- remove extra eta bins
- add error bars to eff. plots and eff. ratio plots
- to get SFs, take weighted average over bins with weights w_i = 1/sig_i^2, where sig_i is the error on each bin
- loop over plotting function instead of copy/paste
- move input ROOT files to directory
- add labels to plots (title, axis, name, etc)
- use fixed x, y ranges in plots 
- save stats in a csv file
- plot (fast sim eff) / (full sim eff) for multiple years
- invert ratio: use (full sim eff) / (fast sim eff)
- use less bins: try 10 bins instead of 20
## NOTES
- Currently for errors on eff. histos, the average of high and low errors from TEfficiency are used. The double ratio has symmetric errors; could maintain asymmetric errors.
- Currently for SF, std_dev is used; could instead propagate unc. through calc. of weighted average.